### PR TITLE
feat: support intMode

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,11 +1,11 @@
-import { libsqlBatchReqStepExecCond, libsqlConfig } from "libsql-stateless";
-import { TransactionMode, rawSQLStatement } from "./types.js";
+import { libsqlBatchReqStepExecCond } from "libsql-stateless";
+import { TransactionMode, rawSQLStatement, libsqlEasyConfig, intMode } from "./types.js";
 import { libsqlBatch, libsqlBatchTransaction, libsqlExecute, libsqlExecuteMultiple, libsqlServerCompatCheck } from "./functions.js";
 import { InternalError, LibsqlError } from "./errors.js";
 import { ____Transaction } from "./extras.js";
 
 class libsqlClient {
-    private readonly conf: libsqlConfig;
+    private readonly conf: libsqlEasyConfig;
     public closed: boolean;
 
     /** Which protocol does the client use?
@@ -16,7 +16,7 @@ class libsqlClient {
      */
     public protocol: string;
 
-    constructor(conf: libsqlConfig) {
+    constructor(conf: libsqlEasyConfig) {
         this.conf = conf;
         this.closed = false;
         this.protocol = "http";
@@ -141,9 +141,11 @@ class libsqlClient {
 export function createClient(conf: {
     url: string;
     authToken?: string;
+    intMode: intMode
 }) {
     return new libsqlClient({
         db_url: conf.url,
-        authToken: conf.authToken
+        authToken: conf.authToken,
+        intMode: conf.intMode
     });
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -19,7 +19,7 @@ function CheckHttpUrl(url: string) {
             throw new LibsqlError((e as Error).message, "ERR_INVALID_URL", (e as Error));
         }
     })();
-    
+
     if (
         _url.protocol !== 'https:' &&
         _url.protocol !== 'http:'
@@ -35,7 +35,7 @@ export async function libsqlExecute(conf: libsqlConfig, stmt: rawSQLStatement): 
 
     const res = await LIBlibsqlExecute(conf, libsqlStatementBuilder(stmt));
 
-    if (res.isOk) return libsqlStatementResParser(res.val);
+    if (res.isOk) return libsqlStatementResParser(res.val, conf.intMode);
     else {
         if (res.err.kind==="LIBSQL_SERVER_ERROR") throw new HttpServerError(res.err.server_message||"Server encountered error.", res.err.http_status_code);
         else throw new ResponseError(res.err.data.message, res.err.data);
@@ -51,7 +51,7 @@ export async function libsqlBatch(
 
     const res = await LIBlibsqlBatch(conf, libsqlBatchReqStepsBuilder(steps, step_conditions));
 
-    if (res.isOk) return libsqlBatchStreamResParser(res.val);
+    if (res.isOk) return libsqlBatchStreamResParser(res.val, conf.intMode);
     else {
         if (res.err.kind==="LIBSQL_SERVER_ERROR") throw new HttpServerError(res.err.server_message||"Server encountered error.", res.err.http_status_code);
         else throw new ResponseError(res.err.data.message, res.err.data);
@@ -74,7 +74,7 @@ export async function libsqlBatchTransaction(
 
     const res = await LIBlibsqlBatch(conf, libsqlTransactionBatchReqStepsBuilder(steps, mode));
 
-    if (res.isOk) return libsqlTransactionBatchStreamResParser(res.val);
+    if (res.isOk) return libsqlTransactionBatchStreamResParser(res.val, conf.intMode);
     else {
         if (res.err.kind==="LIBSQL_SERVER_ERROR") throw new HttpServerError(res.err.server_message||"Server encountered error.", res.err.http_status_code);
         else throw new ResponseError(res.err.data.message, res.err.data);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,15 @@
-export type rawValue = null|bigint|number|string|ArrayBuffer;
+import { libsqlConfig } from "libsql-stateless";
 
+export type rawValue = null|bigint|number|string|ArrayBuffer;
+export type intMode = "bigint" | "number" | "string";
 export type rawSQLStatement = string|{
     sql: string,
     args: Array<rawValue> | Record<string, rawValue>,
     want_rows?: boolean
+}
+
+export interface libsqlEasyConfig extends libsqlConfig {
+    intMode?: intMode
 }
 
 /** Row returned from an SQL statement.


### PR DESCRIPTION
This PR adds `intMode` as a configuration option to match @libsql/client's behavior (however, the default is still `BigInt` to match the behavior of previous versions of libsql-stateless-easy).

Closes #1.

Side note: Could you add something for formatters like a Prettier or editorconfig config file? It would make it a lot easier for people who do not have the same editor settings to contribute and make the code style more uniform.